### PR TITLE
fixed install_cvBlob.sh wget url

### DIFF
--- a/install_cvBlob.sh
+++ b/install_cvBlob.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "--- Installing cvBlob..."
-wget -O cvblob-0.10.4-src.tgz https://cvblob.googlecode.com/files/cvblob-0.10.4-src.tgz
+wget -O cvblob-0.10.4-src.tgz https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/cvblob/cvblob-0.10.4-src.tgz
 tar xzvf cvblob-0.10.4-src.tgz
 cd cvblob/
 mkdir build


### PR DESCRIPTION
Found a simple error since the url for the hosted file changed when Google Code Project Hosting shut down this year. Identified new url and replaced.